### PR TITLE
fix: 修复小程序配置和路径获取问题

### DIFF
--- a/src/utils/Methods.ts
+++ b/src/utils/Methods.ts
@@ -43,7 +43,7 @@ export function getAppBasePath(appid?: string): Promise<string> {
     if (!appid) {
       return Promise.reject({ message: 'appid不能为空' });
     }
-    return Unimp.getUniMPRunPathWithAppid(appid);
+    return Unimp.getAppBasePath(appid);
   }
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,7 +5,7 @@ export declare interface InitializeProps {
   // 胶囊按钮的标题和标识
   items?: { title: string; key: string }[];
   // 是否显示胶囊按钮
-  capsule: boolean;
+  capsule?: boolean;
   // 胶囊按钮字体大小
   fontSize?: string;
   // 胶囊按钮字体颜色

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "esModuleInterop": true,
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
     "lib": ["esnext"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,13 +9,11 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "verbatimModuleSyntax": true,
+    "importsNotUsedAsValues": "error",
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
     "lib": [
-      "esnext",
-      "dom"
+      "esnext"
     ],
     "module": "esnext",
     "moduleResolution": "node",
@@ -29,14 +27,6 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "esnext",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "lib",
-    "isolatedModules": true
-  },
-  "include": [
-    "src"
-  ]
+    "target": "esnext"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,15 +2,21 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "react-native-unimp": ["./src/index"]
+      "react-native-unimp": [
+        "./src/index"
+      ]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "verbatimModuleSyntax": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
-    "lib": ["esnext"],
+    "lib": [
+      "esnext",
+      "dom"
+    ],
     "module": "esnext",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
@@ -23,6 +29,14 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "esnext"
-  }
+    "target": "esnext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "lib",
+    "isolatedModules": true
+  },
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
修复 InitializeProps 接口中 capsule 属性的可选性
更新 tsconfig.json 使用 verbatimModuleSyntax
修正 getAppBasePath 方法调用错误的 API
恢复 iOS 端胶囊按钮和菜单按钮的配置逻辑
完善小程序启动配置参数处理